### PR TITLE
Handle error when creating gateway clients

### DIFF
--- a/pkg/cmd/discovery/discoveryCmd.go
+++ b/pkg/cmd/discovery/discoveryCmd.go
@@ -40,6 +40,10 @@ func run() error {
 	stopChan = make(chan struct{})
 
 	gatewayClient, err := gateway.NewClient(agentConfig)
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		for {
 			err = gatewayClient.DiscoverAPIs()


### PR DESCRIPTION
An error check was missing when creating the client to connect to the kong gateway.