### PR TITLE
APIGOV-26803 - use the service name as the kong proxy id

### DIFF
--- a/pkg/gateway/client.go
+++ b/pkg/gateway/client.go
@@ -268,7 +268,7 @@ func newKongAPI(
 	endpoints []apic.EndpointDefinition,
 ) KongAPI {
 	return KongAPI{
-		id:            *route.ID,
+		id:            *service.Name,
 		name:          *service.Name,
 		description:   oasSpec.Description(),
 		version:       oasSpec.Version(),
@@ -332,16 +332,4 @@ func isPublished(api *KongAPI, c cache.Cache) (bool, string) {
 		return false, checksum
 	}
 	return true, checksum
-}
-
-func isValidAuthTypeAndEnabled(p *klib.Plugin) bool {
-	if !*p.Enabled {
-		return false
-	}
-	for _, availableAuthName := range []string{"basic-auth", "oauth2", "key-auth"} {
-		if *p.Name == availableAuthName {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/traceability/processor/metrics.go
+++ b/pkg/traceability/processor/metrics.go
@@ -54,7 +54,7 @@ func (m *MetricsProcessor) process(entry TrafficLogEntry) (bool, error) {
 
 func (m *MetricsProcessor) updateMetric(entry TrafficLogEntry) {
 	apiDetails := models.APIDetails{
-		ID:    entry.Route.ID,
+		ID:    entry.Service.Name,
 		Name:  entry.Service.Name,
 		Stage: entry.Route.Name,
 	}

--- a/pkg/traceability/processor/transaction.go
+++ b/pkg/traceability/processor/transaction.go
@@ -132,7 +132,7 @@ func createSummaryEvent(ktle TrafficLogEntry, teamID string, txnid string) (*tra
 		SetTeam(teamID).
 		SetEntryPoint(ktle.Service.Protocol, ktle.Request.Method, ktle.Request.URI, ktle.Request.URL).
 		SetDuration(ktle.Latencies.Request).
-		SetProxyWithStage(sdkUtil.FormatProxyID(ktle.Route.ID), ktle.Service.Name, ktle.Route.Name, 1)
+		SetProxyWithStage(sdkUtil.FormatProxyID(ktle.Service.Name), ktle.Service.Name, ktle.Route.Name, 1)
 
 	if ktle.Consumer != nil {
 		builder.SetApplication(sdkUtil.FormatApplicationID(ktle.Consumer.ID), ktle.Consumer.Username)


### PR DESCRIPTION
- Use service name as external api id
- Use route name as external api stage
- Update transaction and metric processing to use service name as api id and route name as api stage 