### PR TITLE
APIGOV-29887 - Support for multiple workspaces 

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,15 +1,19 @@
 package common
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 const (
-	AttrServiceID   = "serviceID"
-	AttrServiceName = "serviceName"
-	AttrRouteName   = "routeName"
-	AttrRouteID     = "routeID"
-	AttrServiceTag  = "serviceTag"
-	AttrChecksum    = "checksum"
-	AttrAppID       = "kongApplicationId"
+	AttrWorkspaceName = "workspaceName"
+	AttrServiceID     = "serviceID"
+	AttrServiceName   = "serviceName"
+	AttrRouteName     = "routeName"
+	AttrRouteID       = "routeID"
+	AttrServiceTag    = "serviceTag"
+	AttrChecksum      = "checksum"
+	AttrAppID         = "kongApplicationId"
 
 	AttrCredentialID = "kongCredentialID"
 	AttrCredUpdater  = "kongCredentialUpdate"
@@ -34,6 +38,9 @@ const (
 	// plugins
 	AclPlugin          = "acl"
 	RateLimitingPlugin = "rate-limiting"
+
+	// Workspace
+	DefaultWorkspace = "default"
 )
 
 type ContextKeys string
@@ -53,4 +60,8 @@ func GetStringValueFromCtx(ctx context.Context, key ContextKeys) string {
 		return ""
 	}
 	return str
+}
+
+func WksPrefixName(workspace, name string) string {
+	return fmt.Sprintf("%s-%s", workspace, name)
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,5 +1,7 @@
 package common
 
+import "context"
+
 const (
 	AttrServiceID   = "serviceID"
 	AttrServiceName = "serviceName"
@@ -33,3 +35,22 @@ const (
 	AclPlugin          = "acl"
 	RateLimitingPlugin = "rate-limiting"
 )
+
+type ContextKeys string
+
+func (c ContextKeys) String() string {
+	return string(c)
+}
+
+const (
+	ContextWorkspace ContextKeys = "workspace"
+)
+
+func GetStringValueFromCtx(ctx context.Context, key ContextKeys) string {
+	ctxVal := ctx.Value(key)
+	str, ok := ctxVal.(string)
+	if !ok {
+		return ""
+	}
+	return str
+}

--- a/pkg/discovery/agent/agent.go
+++ b/pkg/discovery/agent/agent.go
@@ -103,7 +103,7 @@ func NewAgent(agentConfig config.AgentConfig, agentOpts ...func(a *Agent)) (*Age
 	if agentConfig.KongGatewayCfg.ACL.Disable {
 		opts = append(opts, subscription.WithACLDisable())
 	}
-	subscription.NewProvisioner(ka.kongClient, agentConfig.KongGatewayCfg.Workspaces, opts...)
+	subscription.NewProvisioner(ka.kongClient, ka.centralCfg.GetEnvironmentName(), agentConfig.KongGatewayCfg.Workspaces, opts...)
 	return ka, nil
 }
 

--- a/pkg/discovery/agent/agent.go
+++ b/pkg/discovery/agent/agent.go
@@ -88,7 +88,10 @@ func NewAgent(agentConfig config.AgentConfig, agentOpts ...func(a *Agent)) (*Age
 
 	for _, workspaces := range ka.kongGatewayCfg.Workspaces {
 		ctx := context.WithValue(context.Background(), common.ContextWorkspace, workspaces)
-		verifyACLPlugin(ctx, ka, agentConfig.KongGatewayCfg.ACL.Disable)
+		err := verifyACLPlugin(ctx, ka, agentConfig.KongGatewayCfg.ACL.Disable)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ka.filter, err = filter.NewFilter(agentConfig.KongGatewayCfg.Spec.Filter)

--- a/pkg/discovery/agent/agent.go
+++ b/pkg/discovery/agent/agent.go
@@ -51,7 +51,7 @@ type kongClient interface {
 	ListServices(ctx context.Context) ([]*klib.Service, error)
 	ListRoutesForService(ctx context.Context, serviceId string) ([]*klib.Route, error)
 	GetSpecForService(ctx context.Context, service *klib.Service) ([]byte, bool, error)
-	GetKongPlugins() *kong.Plugins
+	GetKongPlugins(ctx context.Context) *kong.Plugins
 }
 
 type Agent struct {
@@ -59,7 +59,6 @@ type Agent struct {
 	centralCfg     corecfg.CentralConfig
 	kongGatewayCfg *config.KongGatewayConfig
 	kongClient     kongClient
-	plugins        kong.Plugins
 	cache          cache.Cache
 	filter         filter.Filter
 }
@@ -75,6 +74,10 @@ func NewAgent(agentConfig config.AgentConfig, agentOpts ...func(a *Agent)) (*Age
 		o(ka)
 	}
 
+	if len(ka.kongGatewayCfg.Workspaces) == 0 {
+		ka.kongGatewayCfg.Workspaces = []string{common.DefaultWorkspace}
+	}
+
 	var err error
 	if ka.kongClient == nil {
 		ka.kongClient, err = kong.NewKongClient(ka.kongGatewayCfg)
@@ -83,13 +86,9 @@ func NewAgent(agentConfig config.AgentConfig, agentOpts ...func(a *Agent)) (*Age
 		return nil, err
 	}
 
-	pluginLister := ka.kongClient.GetKongPlugins()
-	if pluginLister == nil {
-		return nil, fmt.Errorf("could not get kong plugin lister")
-	}
-	plugins, err := ka.kongClient.GetKongPlugins().ListAll(context.Background())
-	if err != nil {
-		return nil, err
+	for _, workspaces := range ka.kongGatewayCfg.Workspaces {
+		ctx := context.WithValue(context.Background(), common.ContextWorkspace, workspaces)
+		verifyACLPlugin(ctx, ka, agentConfig.KongGatewayCfg.ACL.Disable)
 	}
 
 	ka.filter, err = filter.NewFilter(agentConfig.KongGatewayCfg.Spec.Filter)
@@ -97,17 +96,29 @@ func NewAgent(agentConfig config.AgentConfig, agentOpts ...func(a *Agent)) (*Age
 		return nil, err
 	}
 
-	if err = hasGlobalACLEnabledInPlugins(ka.logger, plugins, agentConfig.KongGatewayCfg.ACL.Disable); err != nil {
-		ka.logger.WithError(err).Error("ACL Plugin configured as required, but none found in Kong plugins.")
-		return nil, err
-	}
-
 	opts := []subscription.ProvisionerOption{}
 	if agentConfig.KongGatewayCfg.ACL.Disable {
 		opts = append(opts, subscription.WithACLDisable())
 	}
-	subscription.NewProvisioner(ka.kongClient, opts...)
+	subscription.NewProvisioner(ka.kongClient, agentConfig.KongGatewayCfg.Workspaces, opts...)
 	return ka, nil
+}
+
+func verifyACLPlugin(ctx context.Context, ka *Agent, aclDisable bool) error {
+	pluginLister := ka.kongClient.GetKongPlugins(ctx)
+	if pluginLister == nil {
+		return fmt.Errorf("could not get kong plugin lister")
+	}
+	plugins, err := ka.kongClient.GetKongPlugins(ctx).ListAll(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if err = hasGlobalACLEnabledInPlugins(ka.logger, plugins, aclDisable); err != nil {
+		ka.logger.WithError(err).Error("ACL Plugin configured as required, but none found in Kong plugins.")
+		return err
+	}
+	return nil
 }
 
 func withKongClient(kongClient kongClient) func(a *Agent) {
@@ -140,22 +151,23 @@ func hasGlobalACLEnabledInPlugins(logger log.FieldLogger, plugins []*klib.Plugin
 func (gc *Agent) DiscoverAPIs() error {
 	gc.logger.Info("execute discovery process")
 
-	ctx := context.Background()
-	if len(gc.kongGatewayCfg.Workspaces) > 0 {
-		ctx = context.WithValue(ctx, common.ContextWorkspace, gc.kongGatewayCfg.Workspaces[0])
+	wg := new(sync.WaitGroup)
+	for _, workspace := range gc.kongGatewayCfg.Workspaces {
+		ctx := context.WithValue(context.Background(), common.ContextWorkspace, workspace)
+		services, err := gc.kongClient.ListServices(ctx)
+		if err != nil {
+			gc.logger.WithError(err).Error("failed to get services")
+			return err
+		}
+
+		wg.Add(1)
+		go func(ctx context.Context, service []*klib.Service, wg *sync.WaitGroup) {
+			defer wg.Done()
+			gc.processKongServicesList(ctx, services)
+		}(ctx, services, wg)
 	}
-	var err error
+	wg.Wait()
 
-	plugins := kong.Plugins{PluginLister: gc.kongClient.GetKongPlugins()}
-	gc.plugins = plugins
-
-	services, err := gc.kongClient.ListServices(ctx)
-	if err != nil {
-		gc.logger.WithError(err).Error("failed to get services")
-		return err
-	}
-
-	gc.processKongServicesList(ctx, services)
 	return nil
 }
 
@@ -245,7 +257,7 @@ func (gc *Agent) specPreparation(ctx context.Context, route *klib.Route, service
 		log.Warn("not processing as route name not defined")
 		return
 	}
-	apiPlugins, err := gc.plugins.GetEffectivePlugins(*route.ID, *service.ID)
+	apiPlugins, err := gc.kongClient.GetKongPlugins(ctx).GetEffectivePlugins(*route.ID, *service.ID)
 	if err != nil {
 		log.Warn("could not list plugins")
 		return
@@ -299,7 +311,7 @@ func (gc *Agent) processKongAPI(
 	endpoints []apic.EndpointDefinition,
 	apiPlugins map[string]*klib.Plugin,
 ) (*apic.ServiceBody, error) {
-	kongAPI := newKongAPI(route, service, spec, endpoints, apiPlugins)
+	kongAPI := newKongAPI(ctx, route, service, spec, endpoints, apiPlugins)
 	isAlreadyPublished, checksum := isPublished(&kongAPI, gc.cache)
 	// If true, then the api is published and there were no changes detected
 	if isAlreadyPublished {
@@ -311,11 +323,18 @@ func (gc *Agent) processKongAPI(
 		gc.logger.WithError(err).Error("failed to save api to cache")
 	}
 
-	agentDetails := map[string]string{
-		common.AttrServiceID: *service.ID,
-		common.AttrRouteID:   *route.ID,
-		common.AttrChecksum:  checksum,
+	workspaceName := common.GetStringValueFromCtx(ctx, common.ContextWorkspace)
+	if workspaceName == "" {
+		workspaceName = common.DefaultWorkspace
 	}
+
+	agentDetails := map[string]string{
+		common.AttrServiceID:     *service.ID,
+		common.AttrRouteID:       *route.ID,
+		common.AttrChecksum:      checksum,
+		common.AttrWorkspaceName: workspaceName,
+	}
+
 	kongAPI.agentDetails = agentDetails
 	serviceBody, err := kongAPI.buildServiceBody()
 	if err != nil {
@@ -326,6 +345,7 @@ func (gc *Agent) processKongAPI(
 }
 
 func newKongAPI(
+	ctx context.Context,
 	route *klib.Route,
 	service *klib.Service,
 	spec apic.SpecProcessor,
@@ -346,11 +366,12 @@ func newKongAPI(
 		stageName:     *route.Name,
 		stage:         *route.ID,
 	}
-	ka.processSpecSecurity(spec, apiPlugins)
+	ka.processSpecSecurity(ctx, spec, apiPlugins)
 	return *ka
 }
 
-func (ka *KongAPI) processSpecSecurity(spec apic.SpecProcessor, apiPlugins map[string]*klib.Plugin) {
+func (ka *KongAPI) processSpecSecurity(ctx context.Context, spec apic.SpecProcessor, apiPlugins map[string]*klib.Plugin) {
+	workspace := common.GetStringValueFromCtx(ctx, common.ContextWorkspace)
 	// strip any security from spec if it is an oas spec
 	resType := spec.GetResourceType()
 	if resType != apic.Oas2 && resType != apic.Oas3 {
@@ -363,7 +384,7 @@ func (ka *KongAPI) processSpecSecurity(spec apic.SpecProcessor, apiPlugins map[s
 	ka.crds = []string{}
 	for k, plugin := range apiPlugins {
 		if crd, ok := kongToCRDMapper[k]; ok {
-			ka.crds = append(ka.crds, crd)
+			ka.crds = append(ka.crds, common.WksPrefixName(workspace, crd))
 		}
 		switch k {
 		case kong.BasicAuthPlugin:

--- a/pkg/discovery/agent/agent_test.go
+++ b/pkg/discovery/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/filter"
 	"github.com/Axway/agent-sdk/pkg/util/log"
+	"github.com/Axway/agents-kong/pkg/common"
 	config "github.com/Axway/agents-kong/pkg/discovery/config"
 	"github.com/Axway/agents-kong/pkg/discovery/kong"
 	klib "github.com/kong/go-kong/kong"
@@ -121,12 +122,14 @@ func TestDiscovery(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f, _ := filter.NewFilter("")
 			ka := &Agent{
-				logger:         log.NewFieldLogger().WithComponent("agent").WithPackage("kongAgent"),
-				centralCfg:     corecfg.NewCentralConfig(corecfg.DiscoveryAgent),
-				kongGatewayCfg: &config.KongGatewayConfig{},
-				cache:          cache.New(),
-				kongClient:     tc.client,
-				filter:         f,
+				logger:     log.NewFieldLogger().WithComponent("agent").WithPackage("kongAgent"),
+				centralCfg: corecfg.NewCentralConfig(corecfg.DiscoveryAgent),
+				kongGatewayCfg: &config.KongGatewayConfig{
+					Workspaces: []string{common.DefaultWorkspace},
+				},
+				cache:      cache.New(),
+				kongClient: tc.client,
+				filter:     f,
 			}
 
 			// agent.InitializeForTest()

--- a/pkg/discovery/agent/mockkongclient_test.go
+++ b/pkg/discovery/agent/mockkongclient_test.go
@@ -136,7 +136,7 @@ func (m *mockKongClient) GetSpecForService(ctx context.Context, service *klib.Se
 	return nil, false, fmt.Errorf("unimplemented test func")
 }
 
-func (m *mockKongClient) GetKongPlugins() *kong.Plugins {
+func (m *mockKongClient) GetKongPlugins(ctx context.Context) *kong.Plugins {
 	if m.GetKongPluginsMock != nil {
 		return m.GetKongPluginsMock()
 	}

--- a/pkg/discovery/agent/mockkongclient_test.go
+++ b/pkg/discovery/agent/mockkongclient_test.go
@@ -27,7 +27,7 @@ type mockKongClient struct {
 	// Discovery
 	ListServicesMock         func(context.Context) ([]*klib.Service, error)
 	ListRoutesForServiceMock func(context.Context, string) ([]*klib.Route, error)
-	GetSpecForServiceMock    func(context.Context, *klib.Service) ([]byte, error)
+	GetSpecForServiceMock    func(context.Context, *klib.Service) ([]byte, bool, error)
 	GetKongPluginsMock       func() *kong.Plugins
 }
 
@@ -129,11 +129,11 @@ func (m *mockKongClient) ListRoutesForService(ctx context.Context, serviceId str
 	return nil, fmt.Errorf("unimplemented test func")
 }
 
-func (m *mockKongClient) GetSpecForService(ctx context.Context, service *klib.Service) ([]byte, error) {
+func (m *mockKongClient) GetSpecForService(ctx context.Context, service *klib.Service) ([]byte, bool, error) {
 	if m.GetSpecForServiceMock != nil {
 		return m.GetSpecForServiceMock(ctx, service)
 	}
-	return nil, fmt.Errorf("unimplemented test func")
+	return nil, false, fmt.Errorf("unimplemented test func")
 }
 
 func (m *mockKongClient) GetKongPlugins() *kong.Plugins {

--- a/pkg/discovery/config/config_test.go
+++ b/pkg/discovery/config/config_test.go
@@ -37,13 +37,18 @@ func TestKongGatewayCfg(t *testing.T) {
 	assert.Equal(t, basePathSuffixErr, err.Error())
 
 	cfg.Proxy.BasePath = "/base"
+	cfg.Admin.Url = "http://"
+	err = cfg.ValidateCfg()
+	assert.Equal(t, invalidUrlErr, err.Error())
+
+	cfg.Proxy.BasePath = "/base"
 	cfg.Admin.Url = "sdl.com:8000"
 	err = cfg.ValidateCfg()
 	assert.Equal(t, invalidUrlErr, err.Error())
 
 	cfg.Admin.Url = "http://sdl.com"
 	err = cfg.ValidateCfg()
-	assert.Equal(t, invalidUrlErr, err.Error())
+	assert.Equal(t, nil, err)
 
 	cfg.Admin.Url = "https://sds.com:8000"
 	cfg.Admin.Auth.BasicAuth.Username = "test"

--- a/pkg/discovery/kong/provisioning_test.go
+++ b/pkg/discovery/kong/provisioning_test.go
@@ -207,9 +207,6 @@ func TestCreateCredentials(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			client := createClient(tc.responses)
-			c := client.(*KongClient)
-			c.KeyAuths = mockKeyAuthService{}
 			var err error
 			if tc.expectErr {
 				assert.NotNil(t, err)

--- a/pkg/discovery/subscription/access/access_test.go
+++ b/pkg/discovery/subscription/access/access_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/Axway/agents-kong/pkg/common"
+	klib "github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,6 +18,23 @@ type mockAccessClient struct {
 	addManagedAppErr    bool
 	removeManagedAppErr bool
 	addQuotaErr         bool
+	createAppErr        bool
+	addACLErr           bool
+	consumer            *klib.Consumer
+}
+
+func (m mockAccessClient) CreateConsumer(ctx context.Context, id, name string) (*klib.Consumer, error) {
+	if m.createAppErr {
+		return nil, fmt.Errorf("error")
+	}
+	return m.consumer, nil
+}
+
+func (m mockAccessClient) AddConsumerACL(ctx context.Context, id string) error {
+	if m.addACLErr {
+		return fmt.Errorf("error")
+	}
+	return nil
 }
 
 func (c mockAccessClient) AddRouteACL(ctx context.Context, routeID, allowedID string) error {
@@ -46,6 +64,10 @@ type mockAccessRequest struct {
 	quota   provisioning.Quota
 }
 
+func (a mockAccessRequest) GetApplicationName() string {
+	return ""
+}
+
 func (a mockAccessRequest) GetApplicationDetailsValue(key string) string {
 	if a.values == nil {
 		return ""
@@ -55,6 +77,7 @@ func (a mockAccessRequest) GetApplicationDetailsValue(key string) string {
 	}
 	return ""
 }
+
 func (a mockAccessRequest) GetInstanceDetails() map[string]interface{} {
 	if a.details == nil {
 		return nil

--- a/pkg/discovery/subscription/access/access_test.go
+++ b/pkg/discovery/subscription/access/access_test.go
@@ -2,12 +2,16 @@ package access
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/Axway/agents-kong/pkg/common"
+	"github.com/google/uuid"
 	klib "github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 )
@@ -59,13 +63,14 @@ func (c mockAccessClient) AddQuota(ctx context.Context, routeID, managedAppID, q
 }
 
 type mockAccessRequest struct {
+	appName string
 	values  map[string]string
 	details map[string]interface{}
 	quota   provisioning.Quota
 }
 
 func (a mockAccessRequest) GetApplicationName() string {
-	return ""
+	return a.appName
 }
 
 func (a mockAccessRequest) GetApplicationDetailsValue(key string) string {
@@ -114,20 +119,100 @@ func (q *mockQuota) GetPlanName() string {
 	return q.planName
 }
 
+type mockCentralClient struct {
+	app          *management.ManagedApplication
+	subResources map[string]interface{}
+}
+
+func (c *mockCentralClient) GetResource(url string) (*v1.ResourceInstance, error) {
+	if c.app == nil {
+		return nil, errors.New("app not found")
+	}
+	return c.app.AsInstance()
+}
+
+func (c *mockCentralClient) CreateSubResource(rm v1.ResourceMeta, subs map[string]interface{}) error {
+	c.subResources = subs
+	return nil
+}
+
 func TestProvision(t *testing.T) {
+	appIDAttr := common.WksPrefixName("default", common.AttrAppID)
 	cases := map[string]struct {
 		client     mockAccessClient
 		request    mockAccessRequest
 		result     provisioning.Status
 		aclDisable bool
+		app        *management.ManagedApplication
 	}{
-		"no app id configured": {
+		"no app id configured failure with create consumer": {
+			client: mockAccessClient{
+				createAppErr: true,
+			},
+			request: mockAccessRequest{
+				appName: "test-app",
+			},
+			app:    management.NewManagedApplication("test-app", "test"),
+			result: provisioning.Error,
+		},
+		"no app id configured success create app with acl failure": {
+			client: mockAccessClient{
+				addACLErr: true,
+				consumer: &klib.Consumer{
+					ID: klib.String(uuid.NewString()),
+				},
+			},
+			request: mockAccessRequest{
+				appName: "test-app",
+				details: map[string]interface{}{
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
+				},
+				quota: &mockQuota{
+					interval: provisioning.Daily,
+					limit:    7,
+					planName: "planName",
+				},
+			},
+			app:    management.NewManagedApplication("test-app", "test"),
+			result: provisioning.Success,
+		},
+		"no app id configured success create app": {
+			client: mockAccessClient{
+				consumer: &klib.Consumer{
+					ID: klib.String(uuid.NewString()),
+				},
+			},
+			request: mockAccessRequest{
+				appName: "test-app",
+				details: map[string]interface{}{
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
+				},
+				quota: &mockQuota{
+					interval: provisioning.Daily,
+					limit:    7,
+					planName: "planName",
+				},
+			},
+			app:    management.NewManagedApplication("test-app", "test"),
+			result: provisioning.Success,
+		},
+		"no workspace configured": {
+			request: mockAccessRequest{
+				values: map[string]string{
+					appIDAttr: "appID",
+				},
+				details: map[string]interface{}{
+					common.AttrWorkspaceName: "default",
+				},
+			},
 			result: provisioning.Error,
 		},
 		"no route id configured": {
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 			},
 			result: provisioning.Error,
@@ -135,10 +220,11 @@ func TestProvision(t *testing.T) {
 		"ACL disable is active": {
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 			},
 			result:     provisioning.Success,
@@ -147,10 +233,11 @@ func TestProvision(t *testing.T) {
 		"unsupported quota interval": {
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Weekly,
@@ -166,10 +253,11 @@ func TestProvision(t *testing.T) {
 			},
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Daily,
@@ -185,10 +273,11 @@ func TestProvision(t *testing.T) {
 			},
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Daily,
@@ -202,10 +291,11 @@ func TestProvision(t *testing.T) {
 			client: mockAccessClient{},
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Daily,
@@ -219,14 +309,18 @@ func TestProvision(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testName, name)
-
-			result, _ := NewAccessProvisioner(ctx, tc.client, &tc.request, tc.aclDisable).Provision()
+			prov := NewAccessProvisioner(ctx, tc.client, &tc.request, tc.aclDisable, "test")
+			prov.centralClient = &mockCentralClient{
+				app: tc.app,
+			}
+			result, _ := prov.Provision()
 			assert.Equal(t, tc.result, result.GetStatus())
 		})
 	}
 }
 
 func TestDeprovision(t *testing.T) {
+	appIDAttr := common.WksPrefixName("default", common.AttrAppID)
 	cases := map[string]struct {
 		client     mockAccessClient
 		request    mockAccessRequest
@@ -239,7 +333,7 @@ func TestDeprovision(t *testing.T) {
 		"no route id configured": {
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 			},
 			result: provisioning.Error,
@@ -247,10 +341,11 @@ func TestDeprovision(t *testing.T) {
 		"ACL disable is active": {
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 			},
 			result:     provisioning.Success,
@@ -262,10 +357,11 @@ func TestDeprovision(t *testing.T) {
 			},
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Daily,
@@ -279,10 +375,11 @@ func TestDeprovision(t *testing.T) {
 			client: mockAccessClient{},
 			request: mockAccessRequest{
 				values: map[string]string{
-					common.AttrAppID: "appID",
+					appIDAttr: "appID",
 				},
 				details: map[string]interface{}{
-					common.AttrRouteID: "routeID",
+					common.AttrRouteID:       "routeID",
+					common.AttrWorkspaceName: "default",
 				},
 				quota: &mockQuota{
 					interval: provisioning.Daily,
@@ -297,7 +394,7 @@ func TestDeprovision(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testName, name)
 
-			result := NewAccessProvisioner(ctx, tc.client, &tc.request, tc.aclDisable).Deprovision()
+			result := NewAccessProvisioner(ctx, tc.client, &tc.request, tc.aclDisable, "test").Deprovision()
 			assert.Equal(t, tc.result, result.GetStatus())
 		})
 	}

--- a/pkg/discovery/subscription/application/application.go
+++ b/pkg/discovery/subscription/application/application.go
@@ -73,6 +73,11 @@ func (a AppProvisioner) Deprovision() provisioning.RequestStatus {
 	a.logger.Info("deprovisioning application")
 
 	rs := provisioning.NewRequestStatusBuilder()
+	if len(a.consumerIDs) == 0 {
+		a.logger.Error("could not identify the workspace consumer IDs for the resource")
+		return rs.SetMessage("workspace not found").Failed()
+	}
+
 	for workspace, consumerID := range a.consumerIDs {
 		ctx := context.WithValue(a.ctx, common.ContextWorkspace, workspace)
 		err := a.client.DeleteConsumer(ctx, consumerID)

--- a/pkg/discovery/subscription/application/application_test.go
+++ b/pkg/discovery/subscription/application/application_test.go
@@ -119,7 +119,7 @@ func TestProvision(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testName, name)
 
-			result := NewApplicationProvisioner(ctx, tc.client, &tc.request).Provision()
+			result := NewApplicationProvisioner(ctx, tc.client, &tc.request, []string{common.DefaultWorkspace}).Provision()
 			assert.Equal(t, tc.expectStatus, result.GetStatus())
 			if tc.expectStatus == provisioning.Success {
 				// validate consumerID set
@@ -170,7 +170,7 @@ func TestDeleteConsumer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testName, name)
 
-			result := NewApplicationProvisioner(ctx, tc.client, &tc.request).Deprovision()
+			result := NewApplicationProvisioner(ctx, tc.client, &tc.request, []string{common.DefaultWorkspace}).Deprovision()
 			assert.Equal(t, tc.expectStatus, result.GetStatus())
 		})
 	}

--- a/pkg/discovery/subscription/credential/credential.go
+++ b/pkg/discovery/subscription/credential/credential.go
@@ -72,7 +72,7 @@ func (p credentialProvisioner) Deprovision() provisioning.RequestStatus {
 		return rs.SetMessage("workspace not found").Failed()
 	}
 
-	consumerID := p.request.GetApplicationDetailsValue(common.AttrAppID)
+	consumerID := p.request.GetCredentialDetailsValue(common.AttrAppID)
 	if consumerID == "" {
 		p.logger.Error("could not find the managed application ID on the resource")
 		return rs.SetMessage("managed application ID not found").Failed()
@@ -240,6 +240,7 @@ func (p credentialProvisioner) Update() (provisioning.RequestStatus, provisionin
 				log.WithError(err).Error("Could not create api-key credential")
 				return rs.SetMessage("Failed to create api-key credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			log.Info("API Key successful update")
@@ -259,6 +260,7 @@ func (p credentialProvisioner) Update() (provisioning.RequestStatus, provisionin
 				log.WithError(err).Error("Could not create basic auth credential")
 				return rs.SetMessage("Failed to create basic auth credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			rs.AddProperty(common.AttrCredUpdater, *resp.Username)
@@ -280,6 +282,7 @@ func (p credentialProvisioner) Update() (provisioning.RequestStatus, provisionin
 				log.WithError(err).Error("Could not create oauth2 credential")
 				return rs.SetMessage("Failed to create oauth2 credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			rs.AddProperty(common.AttrCredUpdater, *resp.ClientID)

--- a/pkg/discovery/subscription/credential/credential.go
+++ b/pkg/discovery/subscription/credential/credential.go
@@ -3,6 +3,7 @@ package credential
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/util/log"
@@ -47,16 +48,42 @@ func NewCredentialProvisioner(ctx context.Context, client credentialClient, req 
 	return a
 }
 
-func (p credentialProvisioner) Deprovision() provisioning.RequestStatus {
-	consumerID := p.request.GetApplicationDetailsValue(common.AttrAppID)
-	rs := provisioning.NewRequestStatusBuilder()
-	ctx := context.Background()
+func parseWorkspace(crdName, crdType string) string {
+	return strings.TrimSuffix(crdName, fmt.Sprintf("-%s", crdType))
+}
 
-	credentialType := p.request.GetCredentialType()
+func parseCredentialType(crdName string) (string, string) {
+	switch {
+	case strings.Contains(crdName, provisioning.APIKeyCRD):
+		return parseWorkspace(crdName, provisioning.APIKeyCRD), provisioning.APIKeyCRD
+	case strings.Contains(crdName, provisioning.BasicAuthARD):
+		return parseWorkspace(crdName, provisioning.BasicAuthCRD), provisioning.BasicAuthCRD
+	case strings.Contains(crdName, provisioning.OAuthSecretCRD):
+		return parseWorkspace(crdName, provisioning.OAuthSecretCRD), provisioning.OAuthSecretCRD
+	}
+	return "", ""
+}
+
+func (p credentialProvisioner) Deprovision() provisioning.RequestStatus {
+	rs := provisioning.NewRequestStatusBuilder()
+	workspace, credentialType := parseCredentialType(p.request.GetCredentialType())
+	if workspace == "" {
+		p.logger.Error("could not identify the workspace for the credential resource")
+		return rs.SetMessage("workspace not found").Failed()
+	}
+
+	consumerID := p.request.GetApplicationDetailsValue(common.AttrAppID)
+	if consumerID == "" {
+		p.logger.Error("could not find the managed application ID on the resource")
+		return rs.SetMessage("managed application ID not found").Failed()
+	}
+
 	credentialID := p.request.GetCredentialDetailsValue(common.AttrCredentialID)
 	if credentialID == "" {
 		return rs.SetMessage("CredentialID cannot be empty").Failed()
 	}
+
+	ctx := context.WithValue(context.Background(), common.ContextWorkspace, workspace)
 	log := p.logger.WithField("credentialID", credentialID).
 		WithField("consumerID", consumerID)
 	log.Info("Started credential de-provisioning")
@@ -94,15 +121,21 @@ func (p credentialProvisioner) Deprovision() provisioning.RequestStatus {
 }
 
 func (p credentialProvisioner) Provision() (provisioning.RequestStatus, provisioning.Credential) {
-	consumerID := p.request.GetApplicationDetailsValue(common.AttrAppID)
+	rs := provisioning.NewRequestStatusBuilder()
+	workspace, credentialType := parseCredentialType(p.request.GetCredentialType())
+	if workspace == "" {
+		p.logger.Error("could not identify the workspace for the credential resource")
+		return rs.SetMessage("workspace not found").Failed(), nil
+	}
+
+	consumerID := p.request.GetApplicationDetailsValue(common.WksPrefixName(workspace, common.AttrAppID))
 	agentTag := "amplify-agent"
 	consumerTags := []*string{&agentTag}
 	kongBuilder := NewKongCredentialBuilder().
 		WithConsumerTags(consumerTags)
 
-	ctx := context.Background()
-	rs := provisioning.NewRequestStatusBuilder()
-	credentialType := p.request.GetCredentialType()
+	ctx := context.WithValue(context.Background(), common.ContextWorkspace, workspace)
+
 	log := p.logger.WithField("consumerID", consumerID)
 	log.Info("Started credential provisioning")
 
@@ -116,6 +149,7 @@ func (p credentialProvisioner) Provision() (provisioning.RequestStatus, provisio
 				log.Info("API key unsuccessful provisioning")
 				return rs.SetMessage("Failed to create api-key credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			log.Info("API key successful provisioning")
@@ -133,6 +167,7 @@ func (p credentialProvisioner) Provision() (provisioning.RequestStatus, provisio
 				log.Info("Basic auth unsuccessful provisioning")
 				return rs.SetMessage("Failed to create basic auth credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			rs.AddProperty(common.AttrCredUpdater, *resp.Username)
@@ -150,6 +185,7 @@ func (p credentialProvisioner) Provision() (provisioning.RequestStatus, provisio
 				log.Info("Oauth2 unsuccessful provisioning")
 				return rs.SetMessage("Failed to create oauth2 credential").Failed(), nil
 			}
+			rs.AddProperty(common.AttrWorkspaceName, workspace)
 			rs.AddProperty(common.AttrAppID, *resp.Consumer.ID)
 			rs.AddProperty(common.AttrCredentialID, *resp.ID)
 			rs.AddProperty(common.AttrCredUpdater, *resp.ClientID)
@@ -161,15 +197,25 @@ func (p credentialProvisioner) Provision() (provisioning.RequestStatus, provisio
 }
 
 func (p credentialProvisioner) Update() (provisioning.RequestStatus, provisioning.Credential) {
-	consumerID := p.request.GetApplicationDetailsValue(common.AttrAppID)
+	rs := provisioning.NewRequestStatusBuilder()
+	workspace, credentialType := parseCredentialType(p.request.GetCredentialType())
+	if workspace == "" {
+		p.logger.Error("could not identify the workspace for the credential resource")
+		return rs.SetMessage("workspace not found").Failed(), nil
+	}
+
+	consumerID := p.request.GetCredentialDetailsValue(common.AttrAppID)
+	if workspace == "" {
+		p.logger.Error("could not find the managed application ID on the resource")
+		return rs.SetMessage("managed application ID not found").Failed(), nil
+	}
+
 	agentTag := "amplify-agent"
 	consumerTags := []*string{&agentTag}
 	kongBuilder := NewKongCredentialBuilder().
 		WithConsumerTags(consumerTags)
 
 	ctx := context.Background()
-	rs := provisioning.NewRequestStatusBuilder()
-	credentialType := p.request.GetCredentialType()
 	credentialID := p.request.GetCredentialDetailsValue(common.AttrCredentialID)
 	key := p.request.GetCredentialDetailsValue(common.AttrCredUpdater)
 	if credentialID == "" {

--- a/pkg/discovery/subscription/provision.go
+++ b/pkg/discovery/subscription/provision.go
@@ -36,7 +36,7 @@ type kongClient interface {
 	// Discovery
 	ListServices(ctx context.Context) ([]*klib.Service, error)
 	ListRoutesForService(ctx context.Context, serviceId string) ([]*klib.Route, error)
-	GetSpecForService(ctx context.Context, service *klib.Service) ([]byte, error)
+	GetSpecForService(ctx context.Context, service *klib.Service) ([]byte, bool, error)
 	GetKongPlugins() *kong.Plugins
 }
 

--- a/pkg/discovery/subscription/provision.go
+++ b/pkg/discovery/subscription/provision.go
@@ -44,17 +44,19 @@ type provisioner struct {
 	logger     log.FieldLogger
 	client     kongClient
 	aclDisable bool
+	envName    string
 	workspaces []string
 }
 
 // NewProvisioner creates a type to implement the SDK Provisioning methods for handling subscriptions
-func NewProvisioner(client kongClient, workspaces []string, opts ...ProvisionerOption) {
+func NewProvisioner(client kongClient, envName string, workspaces []string, opts ...ProvisionerOption) {
 	logger := log.NewFieldLogger().WithComponent("provision").WithPackage("subscription")
 	logger.Info("Registering provisioning callbacks")
 	provisioner := &provisioner{
 		client:     client,
 		logger:     logger,
 		workspaces: workspaces,
+		envName:    envName,
 	}
 	for _, o := range opts {
 		o(provisioner)
@@ -95,9 +97,9 @@ func (p provisioner) CredentialUpdate(request provisioning.CredentialRequest) (p
 }
 
 func (p provisioner) AccessRequestProvision(request provisioning.AccessRequest) (provisioning.RequestStatus, provisioning.AccessData) {
-	return access.NewAccessProvisioner(context.Background(), p.client, request, p.aclDisable).Provision()
+	return access.NewAccessProvisioner(context.Background(), p.client, request, p.aclDisable, p.envName).Provision()
 }
 
 func (p provisioner) AccessRequestDeprovision(request provisioning.AccessRequest) provisioning.RequestStatus {
-	return access.NewAccessProvisioner(context.Background(), p.client, request, p.aclDisable).Deprovision()
+	return access.NewAccessProvisioner(context.Background(), p.client, request, p.aclDisable, p.envName).Deprovision()
 }

--- a/pkg/discovery/subscription/register.go
+++ b/pkg/discovery/subscription/register.go
@@ -15,7 +15,7 @@ func getCredTypes() []string {
 	return []string{"confidential", "public"}
 }
 
-func registerOauth2() {
+func registerOauth2(workspace string) {
 	oAuthRedirects := getAuthRedirectSchemaPropertyBuilder()
 	corsProp := getCorsSchemaPropertyBuilder()
 	oAuthTypeProp := provisioning.NewSchemaPropertyBuilder().
@@ -37,32 +37,44 @@ func registerOauth2() {
 		agent.WithCRDRequestSchemaProperty(oAuthRedirects),
 		agent.WithCRDIsRenewable(),
 		agent.WithCRDIsSuspendable(),
-	).Register()
+	).
+		SetName(common.WksPrefixName(workspace, Oauth2Name)).
+		Register()
 	if err != nil {
 		logrus.Errorf("Error registering Oauth2 credential Request %v", err)
 	}
 }
 
-func registerBasicAuth() {
+func registerBasicAuth(workspace string) {
 	corsProp := getCorsSchemaPropertyBuilder()
 	_, err := agent.NewBasicAuthAccessRequestBuilder().SetName(HttpBasicName).Register()
 	if err != nil {
 		logrus.Error("Failed to register Basic Auth Access request")
 	}
-	_, err = agent.NewBasicAuthCredentialRequestBuilder(agent.WithCRDRequestSchemaProperty(corsProp)).IsRenewable().Register()
+	_, err = agent.NewBasicAuthCredentialRequestBuilder(
+		agent.WithCRDRequestSchemaProperty(corsProp),
+	).
+		IsRenewable().
+		SetName(common.WksPrefixName(workspace, HttpBasicName)).
+		Register()
 	if err != nil {
 		logrus.Error("Failed to register Basic Auth Credential request")
 	}
 }
 
-func registerKeyAuth() {
+func registerKeyAuth(workspace string) {
 	//"The api key. Leave empty for autogeneration"
 	corsProp := getCorsSchemaPropertyBuilder()
 	_, err := agent.NewAPIKeyAccessRequestBuilder().SetName(ApiKeyName).Register()
 	if err != nil {
 		logrus.Error("Error registering API key Access Request")
 	}
-	_, err = agent.NewAPIKeyCredentialRequestBuilder(agent.WithCRDRequestSchemaProperty(corsProp)).IsRenewable().Register()
+	_, err = agent.NewAPIKeyCredentialRequestBuilder(
+		agent.WithCRDRequestSchemaProperty(corsProp),
+	).
+		IsRenewable().
+		SetName(common.WksPrefixName(workspace, ApiKeyName)).
+		Register()
 	if err != nil {
 		logrus.Error("Error registering API Credential Access Request")
 	}


### PR DESCRIPTION
- Updates to use workspace specific kong client based on the context
- Updates to setup CRDs for each workspace and associate the workspace specific CRD to associated instances
- Updates to delay application provisioning till initial access request for the application is provisioned to allow creating workspace specific Kong consumer
- Updates to use workspace specific CRD to identify creating credential in Consumer associated to respective workspace